### PR TITLE
Tag vpc and security group, net acl (#1)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,12 +39,27 @@ resource ibm_is_vpc vpc {
   default_security_group_name = "${local.vpc_name}-default"
   default_network_acl_name    = "${local.vpc_name}-default"
   default_routing_table_name  = "${local.vpc_name}-default"
+  tags                        = var.tags
 }
 
 data ibm_is_vpc vpc {
   depends_on = [ibm_is_vpc.vpc]
 
   name = local.vpc_name
+}
+
+resource ibm_resource_tag sg-tag {
+  count = var.provision ? 1 : 0
+  
+  resource_id = local.vpc.default_security_group_crn
+  tags        = var.tags
+}
+
+resource ibm_resource_tag nacl-tag {
+  count = var.provision ? 1 : 0
+
+  resource_id = local.vpc.default_network_acl_crn
+  tags        = var.tags
 }
 
 resource ibm_is_vpc_address_prefix cidr_prefix {
@@ -128,6 +143,7 @@ resource ibm_is_security_group base {
   name = local.base_security_group_name
   vpc  = lookup(local.vpc, "id", "")
   resource_group = local.resource_group_id
+  tags = var.tags
 }
 
 data ibm_is_security_group base {

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,9 @@ variable "internal_cidr" {
   description = "The cidr range of the internal network"
   default     = "10.0.0.0/8"
 }
+
+variable "tags" {
+  type        = list(string)
+  default     = []
+  description = "Tags that should be added to the instance"
+}


### PR DESCRIPTION
* add optional tags to resource

Signed-off-by: Tim Robinson <timroster@gmail.com>

* add tag to base sg

Signed-off-by: Tim Robinson <timroster@gmail.com>

* add tags to default sg/acl

Signed-off-by: Tim Robinson <timroster@gmail.com>

* fix duplicate

Signed-off-by: Tim Robinson <timroster@gmail.com>

* switch to local.vpc

Signed-off-by: Tim Robinson <timroster@gmail.com>

* only tag sg,nacl when provision

Signed-off-by: Tim Robinson <timroster@gmail.com>